### PR TITLE
Fix: Resolve build and packaging errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "concurrently \"npx webpack serve --port 9000\" \"npx tsc -p . -w\" \"wait-on http://localhost:9000/ && electron .\"",
-    "build": "npx webpack --config webpack.config.js && npx tsc -p .",
+    "build": "npx webpack --config webpack.config.js",
     "package": "electron-builder build --publish never",
     "package:win": "electron-builder build --win --publish never",
     "package:mac": "electron-builder build --mac --publish never",


### PR DESCRIPTION
- Modified the build script in package.json to remove a redundant and problematic `tsc` call. Webpack is solely responsible for producing output in the `dist` directory.
- Ensured the `assets/ffmpeg` directory structure is created by running `setup-assets.sh`, addressing a missing path error during packaging.

The user will still need to manually place FFmpeg binaries into `assets/ffmpeg/{platform}` for full FFmpeg functionality. The build process may require Wine if building for Windows on a non-Windows OS.